### PR TITLE
@mzikherman Enable drag and drop support.

### DIFF
--- a/vendor/assets/javascripts/gemini/gemini_upload.js
+++ b/vendor/assets/javascripts/gemini/gemini_upload.js
@@ -79,14 +79,18 @@ $.fn.extend({
   },
   attachFileUploadUI: function(data, options) {
     var $form, bucket, key, metadata, originalKey;
+
     $form = this.find('form');
+    _.defaults(options, {pasteZone: undefined, dropZone: $form});
     bucket = data.policy_document.conditions[0].bucket;
     originalKey = "" + data.policy_document.conditions[1][2] + "/${filename}";
     this.seedForm(data, options);
+
     return $form.fileupload({
       type: 'POST',
       dataType: 'xml',
-      pasteZone: undefined,
+      pasteZone: options.pasteZone,
+      dropZone: options.dropZone,
       done: (function(_this) {
         return function(e, data) {
           var fileName;

--- a/vendor/assets/javascripts/gemini/gemini_upload.js
+++ b/vendor/assets/javascripts/gemini/gemini_upload.js
@@ -86,8 +86,7 @@ $.fn.extend({
     return $form.fileupload({
       type: 'POST',
       dataType: 'xml',
-      pasteZone: null,
-      dropZone: $form,
+      pasteZone: undefined,
       done: (function(_this) {
         return function(e, data) {
           var fileName;


### PR DESCRIPTION
Re: https://github.com/artsy/volt/issues/1822

## Problem
Drag and drop is not working in CMS, and it's because we [set the drop zone to the the form](https://github.com/artsy/gemini_upload-rails/blob/94e19f1b6a9f29e64da35959cab5b3ff10aee8fd/vendor/assets/javascripts/gemini/gemini_upload.js#L90) and on the client we usually hide the form and use our custom UI.

## Solution
Remove the `dropZone` config and use the default (i.e. [`$(document)`](https://github.com/blueimp/jQuery-File-Upload/blob/dd3368cb0b9cf05118c94ffbd3b134fa771a413c/js/jquery.fileupload.js#L92)).

Also updated the `pasteZone` to explicitly use the default (i.e. [`undefined`](https://github.com/blueimp/jQuery-File-Upload/blob/dd3368cb0b9cf05118c94ffbd3b134fa771a413c/js/jquery.fileupload.js#L95)). _I think_ previously the default doesn't work because we use an old version (i.e. [5.10.0](https://github.com/artsy/volt/blob/d40b577cefe56f445aea1975011d93198c69bb3e/app/assets/javascripts/jquery.fileupload.js#L2)) that hasn't supported `pasteZone` yet (it is introduced in [5.17](https://github.com/blueimp/jQuery-File-Upload/commit/6b6bee19fc2c5c831e0801d90edfe4974fde50e0). I will also update jquery.fileupload.js in Volt later.