### PR TITLE
@joeyAghion => Make sure filename gets exposed

### DIFF
--- a/vendor/assets/javascripts/gemini/gemini_upload.js
+++ b/vendor/assets/javascripts/gemini/gemini_upload.js
@@ -109,8 +109,9 @@ $.fn.extend({
         return function(e, data) {
           var fileName, fileType, uid, $key;
           uid = _this.uid();
+          _.extend(data, { uid: uid });
           if (typeof options.onIndividualFile != 'undefined' && options.onIndividualFile != null) {
-            options.onIndividualFile(e, _.extend(data, { uid: uid }));
+            options.onIndividualFile(e, data);
           }
           fileName = data.files[0].name;
           fileType = data.files[0].type;


### PR DESCRIPTION
#minorbug

uid needs to be exposed in `data` so that other callbacks can access it. However, only if the client using this lib even defined an `onIndividualFile` callback would that happen. 

Most clients that use that callback use it to [update the DOM per file for individual progress bars](https://github.com/artsy/volt/blob/ee66bd9bc9c919958ad03f7d63560d02a09b29a8/app/assets/javascripts/gemini_uploads.js.coffee#L18)