### PR TITLE
@joeyAghion => Use S3 key from Gemini credentials response, vs needing to be passed in

### DIFF
--- a/vendor/assets/javascripts/gemini/gemini_upload.js
+++ b/vendor/assets/javascripts/gemini/gemini_upload.js
@@ -38,7 +38,7 @@ $.fn.extend({
     successAction = data.policy_document.conditions[3].success_action_status;
     base64Policy = data.policy_encoded;
     signature = data.signature;
-    s3Key = options.s3Key;
+    s3Key = data.credentials;
     uploadBucket = bucket;
     $form = this.find('form');
     $form.find('input[name=key]').val(key);


### PR DESCRIPTION
This seems like an obvious thing, so I'm not sure why it wasn't done like this in the first place!

The `data.credentials` here refers to https://github.com/artsy/gemini/blob/d4af9c10badc62b5ece9a3f66acab0e33f9588c0/app/util/s3_upload_signer.rb#L15 , where the S3 key that Gemini is using is already being included in the response (but unused).